### PR TITLE
FIX: Using str types for schema.

### DIFF
--- a/schema/validation-report.json
+++ b/schema/validation-report.json
@@ -51,16 +51,8 @@
           "type": "string"
         },
         "path": {
-          "anyOf": [
-            {
-              "format": "path",
-              "type": "string"
-            },
-            {
-              "type": "string"
-            }
-          ],
-          "title": "Path"
+          "title": "Path",
+          "type": "string"
         },
         "size": {
           "default": 0,
@@ -428,8 +420,6 @@
       "default": null
     },
     "uid": {
-      "default": "ff3c57fd-ec6b-418f-b883-e302aea78b41",
-      "format": "uuid",
       "title": "Uid",
       "type": "string"
     }


### PR DESCRIPTION
Fixes schema validation build issue by replacing use of `Path` and `uuid` are replaced by the JSON schema compatible `str` type.